### PR TITLE
Add platform hash to class metadata

### DIFF
--- a/CustomFloorPlugin/Behaviour Descriptors/CustomPlatform.cs
+++ b/CustomFloorPlugin/Behaviour Descriptors/CustomPlatform.cs
@@ -6,6 +6,7 @@ namespace CustomFloorPlugin
     {
         public string platName = "MyCustomPlatform";
         public string platAuthor = "MyName";
+        public string platHash = "";
         public Sprite icon;
 
         public bool hideHighway = false;

--- a/CustomFloorPlugin/PlatformLoader.cs
+++ b/CustomFloorPlugin/PlatformLoader.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 
 namespace CustomFloorPlugin
 {
@@ -65,6 +66,19 @@ namespace CustomFloorPlugin
                 platforms.Add(newPlatform);
                 Plugin.logger.Info("Loaded: " + newPlatform.name);
             }
+
+            using (var md5 = MD5.Create())
+            {
+                using (var stream = File.OpenRead(bundlePath))
+                {
+                    byte[] hash = md5.ComputeHash(stream);
+                    newPlatform.platHash = BitConverter
+                        .ToString(hash)
+                        .Replace("-", string.Empty)
+                        .ToLower();
+                }
+            }
+
             return newPlatform;
         }
         

--- a/CustomFloorPlugin/Properties/AssemblyInfo.cs
+++ b/CustomFloorPlugin/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("CustomFloorPlugin")]
@@ -14,8 +14,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -25,12 +25,12 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.8.2.0")]
-[assembly: AssemblyFileVersion("2.8.2.0")]
+[assembly: AssemblyVersion("2.9.0.0")]
+[assembly: AssemblyFileVersion("2.9.0.0")]

--- a/CustomFloorPlugin/manifest.json
+++ b/CustomFloorPlugin/manifest.json
@@ -1,16 +1,16 @@
 ﻿{
-  "$schema": "https://github.com/nike4613/BSIPA-MetadataFileSchema/master/Schema.json",
+  "$schema": "https://raw.githubusercontent.com/beat-saber-modding-group/BSIPA-MetadataFileSchema/master/Schema.json",
   "author": "Rolo",
   "description": "A plugin to support custom platforms and environments",
   "gameVersion": "1.1.0",
   "id": "Custom Platforms",
   "name": "Custom Platforms",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "features": [
-    
+
   ],
   "dependsOn": {
     "BS Utils": "^1.2.3",
-	"CustomUI": "^1.5.4"
-  },
+    "CustomUI": "^1.5.4"
+  }
 }


### PR DESCRIPTION
Loads the md5 hash of the assetbundle and saves it in the `CustomPlatform.platHash` field.